### PR TITLE
Remove internal scroll container from dashboard timeline

### DIFF
--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -32,15 +32,14 @@
   <!-- Timeline Calendar -->
   <div class="nb-card relative overflow-hidden p-0">
     <!-- Mobile drag hint -->
-    <div class="md:hidden flex items-center justify-between border-b-2 border-black bg-white px-3 py-2">
-      <span class="text-xs font-bold text-black/70">Scroll timeline below</span>
+    <div class="md:hidden flex items-center justify-center border-b-2 border-black bg-white px-3 py-2">
       <span class="text-xs font-bold text-black flex items-center gap-1">
         <span class="inline-block w-3 h-3 rounded bg-black/10 border border-dashed border-black/40"></span>
-        Drag ＋ to add
+        Drag ＋ to add time
       </span>
     </div>
 
-    <div class="timeline-container max-h-[70vh] overflow-y-auto relative" data-time-block-target="timeline">
+    <div class="timeline-container relative" data-time-block-target="timeline">
 
       <% sections = {
         6 => { name: "Your Morning", bg: "bg-morning" },


### PR DESCRIPTION
Let the timeline take its natural height on mobile instead of
constraining it to 70vh with internal scrolling. This allows
the page to scroll normally which feels more natural on mobile.