### PR TITLE
Remove theme comparison section from settings page

### DIFF
--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -48,41 +48,4 @@
     <% end %>
   </div>
 
-  <!-- Theme Comparison -->
-  <div class="nb-card">
-    <h2 class="text-2xl font-black">Theme Comparison</h2>
-    <p class="mt-1 text-sm text-black/70 mb-6">See how your habits will look in each theme.</p>
-
-    <div class="grid gap-6 md:grid-cols-2">
-      <!-- Default Theme Preview -->
-      <div>
-        <p class="nb-label mb-3">Bold & Colorful (Default)</p>
-        <div class="grid grid-cols-4 gap-2">
-          <div class="h-10 border-2 border-black" style="background: #FDE047; box-shadow: 2px 2px 0 #000;"></div>
-          <div class="h-10 border-2 border-black" style="background: #BEF264; box-shadow: 2px 2px 0 #000;"></div>
-          <div class="h-10 border-2 border-black" style="background: #FDA4AF; box-shadow: 2px 2px 0 #000;"></div>
-          <div class="h-10 border-2 border-black" style="background: #F0ABFC; box-shadow: 2px 2px 0 #000;"></div>
-          <div class="h-10 border-2 border-black" style="background: #7DD3FC; box-shadow: 2px 2px 0 #000;"></div>
-          <div class="h-10 border-2 border-black" style="background: #6EE7B7; box-shadow: 2px 2px 0 #000;"></div>
-          <div class="h-10 border-2 border-black" style="background: #FDBA74; box-shadow: 2px 2px 0 #000;"></div>
-          <div class="h-10 border-2 border-black" style="background: #C4B5FD; box-shadow: 2px 2px 0 #000;"></div>
-        </div>
-      </div>
-
-      <!-- Monochrome Theme Preview -->
-      <div>
-        <p class="nb-label mb-3">Monochrome Magic</p>
-        <div class="grid grid-cols-4 gap-2">
-          <div class="h-10 border-2 border-black" style="background: #1f2937; box-shadow: 2px 2px 0 #000;"></div>
-          <div class="h-10 border-2 border-black" style="background: #374151; box-shadow: 2px 2px 0 #000;"></div>
-          <div class="h-10 border-2 border-black" style="background: #4b5563; box-shadow: 2px 2px 0 #000;"></div>
-          <div class="h-10 border-2 border-black" style="background: #6b7280; box-shadow: 2px 2px 0 #000;"></div>
-          <div class="h-10 border-2 border-black" style="background: #9ca3af; box-shadow: 2px 2px 0 #000;"></div>
-          <div class="h-10 border-2 border-black" style="background: #d1d5db; box-shadow: 2px 2px 0 #000;"></div>
-          <div class="h-10 border-2 border-black" style="background: #e5e7eb; box-shadow: 2px 2px 0 #000;"></div>
-          <div class="h-10 border-2 border-black" style="background: #f3f4f6; box-shadow: 2px 2px 0 #000;"></div>
-        </div>
-      </div>
-    </div>
-  </div>
 </div>


### PR DESCRIPTION
## Summary
- Removes the static theme comparison section from the settings page
- Users can simply toggle the theme selector to preview themes in real-time, making the comparison section redundant

## Test plan
- [ ] Visit settings page and confirm theme comparison section is removed
- [ ] Verify theme selector still works and updates preview dynamically