### PR TITLE
Fix time blocks showing from previous days

### DIFF
--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,4 +1,7 @@
 <% content_for :title, "Your Day" %>
+<% content_for :head do %>
+  <meta name="turbo-cache-control" content="no-cache">
+<% end %>
 <div class="nb-page" data-controller="time-block" data-time-block-date-value="<%= @day.date.to_s %>" data-time-block-hour-height-value="60" data-time-block-start-hour-value="6" data-time-block-end-hour-value="24" >
   <%= render "dashboard/header", day: @day %>
   <!-- Timeline Calendar -->


### PR DESCRIPTION
Add turbo-cache-control meta tag to prevent Turbo Drive from caching
the dashboard page. This ensures users always see fresh data filtered
by today's date, rather than cached content from a previous visit.